### PR TITLE
fix typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simple usage looks like:
 ```php
 Commerce\Auth::setApiKey('sk_test_8146250gNZ8gddde480e07ac91c10c2651077176aed27');
 
-$products = Commerce\Product:all();
+$products = Commerce\Product::all();
 
 foreach($products as $k => $product):
 	echo $product['name'];


### PR DESCRIPTION
Getting started instructions in the `README.md` is missing a colon in the code example.