### PR TITLE
Fixing ApiException use call on class ApiResource

### DIFF
--- a/lib/Http/ApiResource.php
+++ b/lib/Http/ApiResource.php
@@ -4,9 +4,9 @@ namespace Commerce\Http;
 
 use Commerce\Http\HttpCallBack;
 use \apimatic\jsonmapper\JsonMapper;
-use Commerce\ApiException;
 use Commerce\ApiHelper;
 use Commerce\Exceptions;
+use Commerce\Http\ApiException;
 use Commerce\Http\HttpRequest;
 use Commerce\Http\HttpResponse;
 use Commerce\Http\HttpMethod;


### PR DESCRIPTION
**Problem:**

The class ApiResource was calling a wrong ApiException namespace.

**Before:**

`use Commerce\ApiException;`

**After:**

`use Commerce\Http\ApiException;`

**Impact:**

Without this fix errors won't be sent to the user.